### PR TITLE
[FTR] Challenge-2 WordCountEngine BucketSort

### DIFF
--- a/techDevGuide/foundational/src/main/java/challenge-2/Challenge2.java
+++ b/techDevGuide/foundational/src/main/java/challenge-2/Challenge2.java
@@ -2,6 +2,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Collections;
+import java.util.LinkedList;
 
 public class Challenge2 {
 
@@ -15,27 +16,56 @@ public class Challenge2 {
         HashMap<String, Node> wordToNodeMap = new HashMap<String, Node>();
         ArrayList<Node> nodes = new ArrayList<Node>();
 
-        buildMap(wordToNodeMap, nodes, document);
-        Collections.sort(nodes, new NodeOrder());
+        int maxCount = buildMap(wordToNodeMap, nodes, document) + 1;
+        ArrayList<LinkedList<Node>> bucket = new ArrayList<LinkedList<Node>>(maxCount);
 
-        if (nodes.isEmpty()) {
-            return new String [0][0];
+        // Build the bucket sort
+        // Initialize
+        for (int count = 0; count < maxCount; count++) {
+            bucket.add(null);
+        }
+
+        // Iterate through the ordered list.
+        for (Node node : nodes) {
+            if (node != null) {
+                LinkedList<Node> orderedNodes = bucket.get(node.wordCount);
+                if (orderedNodes == null) {
+                    // new bucket.
+                    orderedNodes = new LinkedList<Node>();
+                }
+                
+                // Insert the node into the bucket
+                orderedNodes.add(wordToNodeMap.get(node.word));
+
+                // make sure to put the bucket back
+                bucket.set(node.wordCount, orderedNodes);
+            }
         }
 
         result = new String [nodes.size()][2];
         int resultIndex = 0;
 
-        for (Node node : nodes) {
-            result[resultIndex][0] = node.word;
-            result[resultIndex][1] = Integer.toString(node.wordCount);
-            resultIndex++;
+        // Now iterate from the high index backwards in the bucket list.
+        for (int count = 0; count < maxCount; count++) {
+            LinkedList<Node> orderedNodes = bucket.get(maxCount - 1 - count);
+            
+            if (orderedNodes != null) {
+                // The bucket at the index is not empty.
+                while (!orderedNodes.isEmpty()) {
+                    Node node = orderedNodes.remove();
+                    result[resultIndex][0] = node.word;
+                    result[resultIndex][1] = Integer.toString(node.wordCount);
+                    resultIndex++;
+                }
+            }    
         }
 
         return result;
     }
 
-    private static void buildMap(HashMap<String, Node> map, ArrayList<Node> nodes, String document) {
+    private static int buildMap(HashMap<String, Node> map, ArrayList<Node> nodes, String document) {
         int wordIndex = 0;
+        int maxCount = 0;
 
         for (int leftIndex = 0; leftIndex < document.length(); leftIndex++) {
             char character = document.charAt(leftIndex);
@@ -67,11 +97,20 @@ public class Challenge2 {
                 if (map.containsKey(word)) {
                     node = map.get(word);
                     node.wordCount++;
+
+                    if (node.wordCount > maxCount) {
+                        maxCount = node.wordCount;
+                    }
                 }
                 else {
                     node = new Node(word, wordIndex);
                     wordIndex++; 
-                    nodes.add(node);   
+                    // Adding the node to the list will preserve order of new nodes.
+                    nodes.add(node);  
+                    
+                    if (1 > maxCount) {
+                        maxCount = 1;
+                    }
                 }
 
                 map.put(word, node);
@@ -80,6 +119,8 @@ public class Challenge2 {
                 // dont handle it.
             }
         }
+
+        return maxCount;
     }
 
     private static class Node {
@@ -113,7 +154,7 @@ public class Challenge2 {
     }
 
     public static void main(String args []) {
-        String document = "perfect Practice makes . you'll only get Perfect by practice. just do it!";
+        String document = " Practice  perfect makes . you'll only get Perfect by practice. just do it!";
 
         for (String [] strings : wordCountEngine(document)) {
             for (String word : strings) {


### PR DESCRIPTION
Feature Development

Replaced the call to the `Collections.sort()` method on the NodeOrder
`Comparator` usage to remove the `O(NlgN)` sort time in the worse case.

The use of bucket sort however does use more memory and if the distribution
is sparse could lead to memory inefficiencies.

Related Issues
- #8