### PR TITLE
[PR] C++ STL Associative Containers

### DIFF
--- a/prototype/src/cpp/stl/stl_associative_containers.cpp
+++ b/prototype/src/cpp/stl/stl_associative_containers.cpp
@@ -1,0 +1,44 @@
+#include <cstdlib>
+#include <iostream>
+#include <set>
+
+using namespace std;
+
+class MyComparable { 
+    public:
+        bool operator() (const int & num1, const int & num2) {
+            if (num1 < num2) {
+                return false;
+            }
+            return true;
+        }
+};
+
+struct classcomp {
+  bool operator() (const int& lhs, const int& rhs) const
+  {return lhs<rhs;}
+};
+
+template <typename T>
+void print(T data) {
+    cout << endl;
+    for (auto it = data.begin(); it != data.end(); ++it) {
+        cout << *it << " ";
+    }
+    cout << endl;
+}
+
+int main(int argc, char * argv[]) {
+    set<int> myset;
+    set<int, MyComparable> compSet;
+
+    for (int i = 0; i < 10; i++) {
+        myset.insert(i);
+        compSet.insert(i);
+    }
+
+    print(myset);
+    print(compSet);
+
+    return 0;
+}

--- a/prototype/src/cpp/stl/stl_associative_containers.cpp
+++ b/prototype/src/cpp/stl/stl_associative_containers.cpp
@@ -29,7 +29,8 @@ void print(T data) {
 }
 
 int main(int argc, char * argv[]) {
-    set<int> myset;
+    int values [] = {1, 15, 29, 13, 11, 7, 9, 11, -1};
+    multiset<int> myset (values, values+8);
     set<int, MyComparable> compSet;
 
     for (int i = 0; i < 10; i++) {

--- a/prototype/src/cpp/stl/stl_associative_containers.cpp
+++ b/prototype/src/cpp/stl/stl_associative_containers.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <set>
+#include <map>
 
 using namespace std;
 
@@ -32,14 +33,17 @@ int main(int argc, char * argv[]) {
     int values [] = {1, 15, 29, 13, 11, 7, 9, 11, -1};
     multiset<int> myset (values, values+8);
     set<int, MyComparable> compSet;
+    map<int, int> myMap;
 
     for (int i = 0; i < 10; i++) {
         myset.insert(i);
         compSet.insert(i);
+        myMap.insert(pair<int, int> (i, i * -1));
     }
 
     print(myset);
     print(compSet);
+    // print(myMap);
 
     return 0;
 }


### PR DESCRIPTION
Working with the C++ STL associative containers of map, set, and multiset.  These are ordered and therefore a comparable definition can be provided at time of construction.